### PR TITLE
Remove duplicate foreign definition in Web.HTML.HTMLInputElement.

### DIFF
--- a/src/Web/HTML/HTMLInputElement.js
+++ b/src/Web/HTML/HTMLInputElement.js
@@ -588,22 +588,6 @@ exports["stepDown'"] = function (n) {
 
 // ----------------------------------------------------------------------------
 
-exports.value = function (input) {
-  return function () {
-    return input.value;
-  };
-};
-
-exports.setValue = function (value) {
-  return function (input) {
-    return function () {
-      input.value = value;
-    };
-  };
-};
-
-// ----------------------------------------------------------------------------
-
 exports.willValidate = function (input) {
   return function () {
     return input.willValidate;


### PR DESCRIPTION
These two functions are defined twice in the file right now.