### PR TITLE
Fix type of Web.HTML.Window.(scrollX|scrollY)

### DIFF
--- a/src/Web/HTML/Window.purs
+++ b/src/Web/HTML/Window.purs
@@ -111,9 +111,9 @@ foreign import scroll :: Int -> Int -> Window -> Effect Unit
 
 foreign import scrollBy :: Int -> Int -> Window -> Effect Unit
 
-foreign import scrollX :: Window -> Effect Int
+foreign import scrollX :: Window -> Effect Number
 
-foreign import scrollY :: Window -> Effect Int
+foreign import scrollY :: Window -> Effect Number
 
 foreign import localStorage :: Window -> Effect Storage
 


### PR DESCRIPTION
See [scrollY](https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollY) and [scrollX](https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollX) in `Web.HTML.Window` - these functions can return subpixel values on scaled screens.

This intends to close #16 