### PR TITLE
Remove primes from foreign modules exports

### DIFF
--- a/src/Web/HTML/HTMLImageElement.js
+++ b/src/Web/HTML/HTMLImageElement.js
@@ -7,7 +7,7 @@ exports.create = function () {
   };
 };
 
-exports["create'"] = function (width) {
+exports.createWithDimensions = function (width) {
   return function (height) {
     return function () {
       return new Image(width, height);

--- a/src/Web/HTML/HTMLImageElement.purs
+++ b/src/Web/HTML/HTMLImageElement.purs
@@ -1,4 +1,39 @@
-module Web.HTML.HTMLImageElement where
+module Web.HTML.HTMLImageElement
+  ( HTMLImageElement
+  , fromHTMLElement
+  , fromElement
+  , fromNode
+  , fromChildNode
+  , fromNonDocumentTypeChildNode
+  , fromParentNode
+  , fromEventTarget
+  , toHTMLElement
+  , toElement
+  , toNode
+  , toChildNode
+  , toNonDocumentTypeChildNode
+  , toParentNode
+  , toEventTarget
+  , create
+  , create'
+  , alt
+  , setAlt
+  , src
+  , setSrc
+  , crossOrigin
+  , setCrossOrigin
+  , useMap
+  , setUseMap
+  , isMap
+  , setIsMap
+  , width
+  , setWidth
+  , height
+  , setHeight
+  , naturalWidth
+  , naturalHeight
+  , complete
+  ) where
 
 import Data.Maybe (Maybe)
 import Effect (Effect)
@@ -55,7 +90,10 @@ toEventTarget = unsafeCoerce
 
 
 foreign import create :: Unit -> Effect HTMLImageElement
-foreign import create' :: Int -> Int -> Effect HTMLImageElement
+foreign import createWithDimensions :: Int -> Int -> Effect HTMLImageElement
+
+create' :: Int -> Int -> Effect HTMLImageElement
+create' = createWithDimensions
 
 foreign import alt :: HTMLImageElement -> Effect String
 foreign import setAlt :: String -> HTMLImageElement -> Effect Unit

--- a/src/Web/HTML/HTMLInputElement.js
+++ b/src/Web/HTML/HTMLInputElement.js
@@ -568,7 +568,7 @@ exports.setWidth = function (width) {
 
 // ----------------------------------------------------------------------------
 
-exports["stepUp'"] = function (n) {
+exports.stepUpBy = function (n) {
   return function (input) {
     return function () {
       input.stepUp(n);
@@ -578,7 +578,7 @@ exports["stepUp'"] = function (n) {
 
 // ----------------------------------------------------------------------------
 
-exports["stepDown'"] = function (n) {
+exports.stepDownBy = function (n) {
   return function (input) {
     return function () {
       input.stepDown(n);

--- a/src/Web/HTML/HTMLInputElement.purs
+++ b/src/Web/HTML/HTMLInputElement.purs
@@ -290,12 +290,18 @@ foreign import setWidth :: Int -> HTMLInputElement -> Effect Unit
 stepUp :: HTMLInputElement -> Effect Unit
 stepUp = stepUp' 1
 
-foreign import stepUp' :: Int -> HTMLInputElement -> Effect Unit
+foreign import stepUpBy :: Int -> HTMLInputElement -> Effect Unit
+
+stepUp' :: Int -> HTMLInputElement -> Effect Unit
+stepUp' = stepUpBy
 
 stepDown :: HTMLInputElement -> Effect Unit
 stepDown = stepDown' 1
 
-foreign import stepDown' :: Int -> HTMLInputElement -> Effect Unit
+foreign import stepDownBy :: Int -> HTMLInputElement -> Effect Unit
+
+stepDown' :: Int -> HTMLInputElement -> Effect Unit
+stepDown' = stepDownBy
 
 foreign import willValidate :: HTMLInputElement -> Effect Boolean
 

--- a/src/Web/HTML/HTMLTableElement.js
+++ b/src/Web/HTML/HTMLTableElement.js
@@ -120,7 +120,7 @@ exports.rows = function (table) {
 
 // ----------------------------------------------------------------------------
 
-exports["insertRow'"] = function (index) {
+exports.insertRowAt = function (index) {
   return function (table) {
     return function () {
       return table.insertRow(index);

--- a/src/Web/HTML/HTMLTableElement.purs
+++ b/src/Web/HTML/HTMLTableElement.purs
@@ -138,7 +138,10 @@ foreign import rows :: HTMLTableElement -> Effect HTMLCollection
 insertRow :: HTMLTableElement -> Effect HTMLElement
 insertRow = insertRow' (-1)
 
-foreign import insertRow' :: Int -> HTMLTableElement -> Effect HTMLElement
+foreign import insertRowAt :: Int -> HTMLTableElement -> Effect HTMLElement
+
+insertRow' :: Int -> HTMLTableElement -> Effect HTMLElement
+insertRow' = insertRowAt
 
 foreign import deleteRow :: Int -> HTMLTableElement -> Effect Unit
 

--- a/src/Web/HTML/HTMLTableRowElement.js
+++ b/src/Web/HTML/HTMLTableRowElement.js
@@ -32,7 +32,7 @@ exports.cells = function (row) {
 
 // ----------------------------------------------------------------------------
 
-exports["insertCell'"] = function (index) {
+exports.insertCellAt = function (index) {
   return function (row) {
     return function () {
       return row.insertCell(index);

--- a/src/Web/HTML/HTMLTableRowElement.purs
+++ b/src/Web/HTML/HTMLTableRowElement.purs
@@ -1,4 +1,26 @@
-module Web.HTML.HTMLTableRowElement where
+module Web.HTML.HTMLTableRowElement
+  ( HTMLTableRowElement
+  , fromHTMLElement
+  , fromElement
+  , fromNode
+  , fromChildNode
+  , fromNonDocumentTypeChildNode
+  , fromParentNode
+  , fromEventTarget
+  , toHTMLElement
+  , toElement
+  , toNode
+  , toChildNode
+  , toNonDocumentTypeChildNode
+  , toParentNode
+  , toEventTarget
+  , rowIndex
+  , sectionRowIndex
+  , cells
+  , insertCell
+  , insertCell'
+  , deleteCell
+  ) where
 
 import Data.Maybe (Maybe)
 import Effect (Effect)
@@ -63,6 +85,9 @@ foreign import cells :: HTMLTableRowElement -> Effect HTMLCollection
 insertCell :: HTMLTableRowElement -> Effect HTMLElement
 insertCell = insertCell' (-1)
 
-foreign import insertCell' :: Int -> HTMLTableRowElement -> Effect HTMLElement
+foreign import insertCellAt :: Int -> HTMLTableRowElement -> Effect HTMLElement
+
+insertCell' :: Int -> HTMLTableRowElement -> Effect HTMLElement
+insertCell' = insertCellAt
 
 foreign import deleteCell :: Int -> HTMLTableRowElement -> Effect Unit

--- a/src/Web/HTML/HTMLTableSectionElement.js
+++ b/src/Web/HTML/HTMLTableSectionElement.js
@@ -8,7 +8,7 @@ exports.rows = function (section) {
 
 // ----------------------------------------------------------------------------
 
-exports["insertRow'"] = function (index) {
+exports.insertRowAt = function (index) {
   return function (section) {
     return function () {
       return section.insertRow(index);

--- a/src/Web/HTML/HTMLTableSectionElement.purs
+++ b/src/Web/HTML/HTMLTableSectionElement.purs
@@ -1,4 +1,24 @@
-module Web.HTML.HTMLTableSectionElement where
+module Web.HTML.HTMLTableSectionElement
+  ( HTMLTableSectionElement
+  , fromHTMLElement
+  , fromElement
+  , fromNode
+  , fromChildNode
+  , fromNonDocumentTypeChildNode
+  , fromParentNode
+  , fromEventTarget
+  , toHTMLElement
+  , toElement
+  , toNode
+  , toChildNode
+  , toNonDocumentTypeChildNode
+  , toParentNode
+  , toEventTarget
+  , rows
+  , insertRow
+  , insertRow'
+  , deleteRow
+  ) where
 
 import Prelude
 
@@ -60,6 +80,9 @@ foreign import rows :: HTMLTableSectionElement -> Effect HTMLCollection
 insertRow :: HTMLTableSectionElement -> Effect HTMLElement
 insertRow = insertRow' (-1)
 
-foreign import insertRow' :: Int -> HTMLTableSectionElement -> Effect HTMLElement
+foreign import insertRowAt :: Int -> HTMLTableSectionElement -> Effect HTMLElement
+
+insertRow' :: Int -> HTMLTableSectionElement -> Effect HTMLElement
+insertRow' = insertRowAt
 
 foreign import deleteRow :: Int -> HTMLTableSectionElement -> Effect Unit


### PR DESCRIPTION
Primes in foreign modules exports will be deprecated in v0.14.0. See https://github.com/purescript/purescript/pull/3792.