### PR TITLE
Fix `HiddenConstructors` warnings

### DIFF
--- a/src/Web/HTML/Window.js
+++ b/src/Web/HTML/Window.js
@@ -188,7 +188,7 @@ exports.sessionStorage = function (window) {
   };
 };
 
-exports._requestAnimationFrame = function(fn) {
+exports.requestAnimationFrame = function(fn) {
   return function(window) {
     return function() {
       return window.requestAnimationFrame(fn);
@@ -196,7 +196,7 @@ exports._requestAnimationFrame = function(fn) {
   };
 };
 
-exports._cancelAnimationFrame = function(id) {
+exports.cancelAnimationFrame = function(id) {
   return function(window) {
     return function() {
       return window.cancelAnimationFrame(id);
@@ -204,7 +204,7 @@ exports._cancelAnimationFrame = function(id) {
   };
 };
 
-exports._requestIdleCallback = function(opts) {
+exports.requestIdleCallback = function(opts) {
   return function(fn) {
     return function(window) {
       return function() {
@@ -214,7 +214,7 @@ exports._requestIdleCallback = function(opts) {
   };
 };
 
-exports._cancelIdleCallback = function(id) {
+exports.cancelIdleCallback = function(id) {
   return function(window) {
     return function() {
       return window.cancelIdleCallback(id);

--- a/src/Web/HTML/Window.purs
+++ b/src/Web/HTML/Window.purs
@@ -40,7 +40,7 @@ module Web.HTML.Window
 import Data.Maybe (Maybe)
 import Data.Nullable (Nullable, toMaybe)
 import Effect (Effect)
-import Prelude (class Eq, class Ord, Unit, (<$>), (<<<), map)
+import Prelude (class Eq, class Ord, Unit, (<$>))
 import Unsafe.Coerce (unsafeCoerce)
 import Web.Event.EventTarget (EventTarget)
 import Web.HTML.HTMLDocument (HTMLDocument)

--- a/src/Web/HTML/Window.purs
+++ b/src/Web/HTML/Window.purs
@@ -38,7 +38,6 @@ module Web.HTML.Window
   ) where
 
 import Data.Maybe (Maybe)
-import Data.Newtype (class Newtype, unwrap)
 import Data.Nullable (Nullable, toMaybe)
 import Effect (Effect)
 import Prelude (class Eq, class Ord, Unit, (<$>), (<<<), map)
@@ -121,37 +120,23 @@ foreign import sessionStorage :: Window -> Effect Storage
 
 newtype RequestAnimationFrameId = RequestAnimationFrameId Int
 
-derive instance newtypeRequestAnimationFrameId :: Newtype RequestAnimationFrameId _
 derive instance eqRequestAnimationFrameId :: Eq RequestAnimationFrameId
 derive instance ordRequestAnimationFrameId :: Ord RequestAnimationFrameId
 
-foreign import _requestAnimationFrame :: Effect Unit -> Window -> Effect Int
+foreign import requestAnimationFrame :: Effect Unit -> Window -> Effect RequestAnimationFrameId
 
-requestAnimationFrame :: Effect Unit -> Window -> Effect RequestAnimationFrameId
-requestAnimationFrame fn = map RequestAnimationFrameId <<< _requestAnimationFrame fn
-
-foreign import _cancelAnimationFrame :: Int -> Window -> Effect Unit
-
-cancelAnimationFrame :: RequestAnimationFrameId -> Window -> Effect Unit
-cancelAnimationFrame idAF = _cancelAnimationFrame (unwrap idAF)
+foreign import cancelAnimationFrame :: RequestAnimationFrameId -> Window -> Effect Unit
 
 newtype RequestIdleCallbackId = RequestIdleCallbackId Int
 
-derive instance newtypeRequestIdleCallbackId :: Newtype RequestIdleCallbackId _
 derive instance eqRequestIdleCallbackId :: Eq RequestIdleCallbackId
 derive instance ordRequestIdleCallbackId :: Ord RequestIdleCallbackId
 
-foreign import _requestIdleCallback :: { timeout :: Int } -> Effect Unit -> Window -> Effect Int
-
 -- | Set timeout to `0` to get the same behaviour as when it is `undefined` in
 -- | [JavaScript](https://w3c.github.io/requestidlecallback/#h-the-requestidle-callback-method).
-requestIdleCallback :: { timeout :: Int } -> Effect Unit -> Window -> Effect RequestIdleCallbackId
-requestIdleCallback opts fn = map RequestIdleCallbackId <<< _requestIdleCallback opts fn
+foreign import requestIdleCallback :: { timeout :: Int } -> Effect Unit -> Window -> Effect RequestIdleCallbackId
 
-foreign import _cancelIdleCallback :: Int -> Window -> Effect Unit
-
-cancelIdleCallback :: RequestIdleCallbackId -> Window -> Effect Unit
-cancelIdleCallback idAF = _cancelIdleCallback (unwrap idAF)
+foreign import cancelIdleCallback :: RequestIdleCallbackId -> Window -> Effect Unit
 
 foreign import parent :: Window -> Effect Window
 


### PR DESCRIPTION
Exported types with hidden constructors but `Generic` or `Newtype` instances will trigger a warning in v0.14.0.

See https://github.com/purescript/purescript/pull/3907.