### PR TITLE
img attrs: srcset, currentSrc, sizes, referrerPolicy, decoding, loading

### DIFF
--- a/src/Web/HTML/HTMLImageElement.js
+++ b/src/Web/HTML/HTMLImageElement.js
@@ -89,18 +89,12 @@ exports.currentSrc = function (image) {
 
 // ----------------------------------------------------------------------------
 
-exports.crossOrigin = function (image) {
-  return function () {
-    return image.crossOrigin;
-  };
+exports._crossOrigin = function (image) {
+  return image.crossOrigin;
 };
 
-exports.setCrossOrigin = function (crossOrigin) {
-  return function (image) {
-    return function () {
-      image.crossOrigin = crossOrigin;
-    };
-  };
+exports._setCrossOrigin = function (crossOrigin, image) {
+  image.crossOrigin = crossOrigin;
 };
 
 // ----------------------------------------------------------------------------
@@ -200,34 +194,22 @@ exports.setReferrerPolicy = function (referrerPolicy) {
 
 // ----------------------------------------------------------------------------
 
-exports.decoding = function (image) {
-  return function () {
-    return image.decoding;
-  };
+exports._decoding = function (image) {
+  return image.decoding;
 };
 
-exports.setDecoding = function (decoding) {
-  return function (image) {
-    return function () {
-      image.decoding = decoding;
-    };
-  };
+exports._setDecoding = function (decoding, image) {
+  image.decoding = decoding;
 };
 
 // ----------------------------------------------------------------------------
 
-exports.loading = function (image) {
-  return function () {
-    return image.loading;
-  };
+exports._loading = function (image) {
+  return image.loading;
 };
 
-exports.setLoading = function (loading) {
-  return function (image) {
-    return function () {
-      image.loading = loading;
-    };
-  };
+exports._setLoading = function (loading, image) {
+  image.loading = loading;
 };
 
 // ----------------------------------------------------------------------------

--- a/src/Web/HTML/HTMLImageElement.js
+++ b/src/Web/HTML/HTMLImageElement.js
@@ -49,6 +49,46 @@ exports.setSrc = function (src) {
 
 // ----------------------------------------------------------------------------
 
+exports.srcset = function (image) {
+  return function () {
+    return image.srcset;
+  };
+};
+
+exports.setSrcset = function (srcset) {
+  return function (image) {
+    return function () {
+      image.srcset = srcset;
+    };
+  };
+};
+
+// ----------------------------------------------------------------------------
+
+exports.sizes = function (image) {
+  return function () {
+    return image.sizes;
+  };
+};
+
+exports.setSizes = function (sizes) {
+  return function (image) {
+    return function () {
+      image.sizes = sizes;
+    };
+  };
+};
+
+// ----------------------------------------------------------------------------
+
+exports.currentSrc = function (image) {
+  return function () {
+    return image.currentSrc;
+  };
+};
+
+// ----------------------------------------------------------------------------
+
 exports.crossOrigin = function (image) {
   return function () {
     return image.crossOrigin;
@@ -138,6 +178,55 @@ exports.naturalWidth = function (image) {
 exports.naturalHeight = function (image) {
   return function () {
     return image.naturalHeight;
+  };
+};
+
+// ----------------------------------------------------------------------------
+
+exports.referrerPolicy = function (image) {
+  return function () {
+    return image.referrerPolicy;
+  };
+};
+
+exports.setReferrerPolicy = function (referrerPolicy) {
+  return function (image) {
+    return function () {
+      image.referrerPolicy = referrerPolicy;
+    };
+  };
+};
+
+
+// ----------------------------------------------------------------------------
+
+exports.decoding = function (image) {
+  return function () {
+    return image.decoding;
+  };
+};
+
+exports.setDecoding = function (decoding) {
+  return function (image) {
+    return function () {
+      image.decoding = decoding;
+    };
+  };
+};
+
+// ----------------------------------------------------------------------------
+
+exports.loading = function (image) {
+  return function () {
+    return image.loading;
+  };
+};
+
+exports.setLoading = function (loading) {
+  return function (image) {
+    return function () {
+      image.loading = loading;
+    };
   };
 };
 

--- a/src/Web/HTML/HTMLImageElement.purs
+++ b/src/Web/HTML/HTMLImageElement.purs
@@ -23,6 +23,8 @@ module Web.HTML.HTMLImageElement
   , srcset
   , setSrcset
   , currentSrc
+  , sizes
+  , setSizes
   , crossOrigin
   , setCrossOrigin
   , useMap
@@ -44,13 +46,22 @@ module Web.HTML.HTMLImageElement
   , complete
   ) where
 
-import Data.Maybe (Maybe)
+import Data.Nullable (Nullable)
+import Data.Nullable as Nullable
+import Data.Maybe (Maybe, fromMaybe)
 import Effect (Effect)
-import Prelude (Unit)
+import Effect.Uncurried (EffectFn1, EffectFn2, runEffectFn1, runEffectFn2)
+import Prelude (Unit, map, (<<<), (<=<))
 import Unsafe.Coerce (unsafeCoerce)
 import Web.DOM (ChildNode, Element, Node, NonDocumentTypeChildNode, ParentNode)
 import Web.Event.EventTarget (EventTarget)
 import Web.HTML.HTMLElement (HTMLElement)
+import Web.HTML.HTMLImageElement.CORSMode (CORSMode)
+import Web.HTML.HTMLImageElement.CORSMode as CORSMode
+import Web.HTML.HTMLImageElement.DecodingHint (DecodingHint)
+import Web.HTML.HTMLImageElement.DecodingHint as DecodingHint
+import Web.HTML.HTMLImageElement.Laziness (Laziness)
+import Web.HTML.HTMLImageElement.Laziness as Laziness
 import Web.Internal.FFI (unsafeReadProtoTagged)
 
 foreign import data HTMLImageElement :: Type
@@ -118,8 +129,15 @@ foreign import currentSrc :: HTMLImageElement -> Effect String
 foreign import sizes :: HTMLImageElement -> Effect String
 foreign import setSizes :: String -> HTMLImageElement -> Effect Unit
 
-foreign import crossOrigin :: HTMLImageElement -> Effect String
-foreign import setCrossOrigin :: String -> HTMLImageElement -> Effect Unit
+foreign import _crossOrigin :: EffectFn1 HTMLImageElement (Nullable String)
+
+crossOrigin :: HTMLImageElement -> Effect (Maybe CORSMode)
+crossOrigin = map (CORSMode.parse <=< Nullable.toMaybe) <<< runEffectFn1 _crossOrigin
+
+foreign import _setCrossOrigin :: EffectFn2 String HTMLImageElement Unit
+
+setCrossOrigin :: CORSMode -> HTMLImageElement -> Effect Unit
+setCrossOrigin mode = runEffectFn2 _setCrossOrigin (CORSMode.print mode)
 
 foreign import useMap :: HTMLImageElement -> Effect String
 foreign import setUseMap :: String -> HTMLImageElement -> Effect Unit
@@ -139,10 +157,24 @@ foreign import naturalHeight :: HTMLImageElement -> Effect Int
 foreign import referrerPolicy :: HTMLImageElement -> Effect String
 foreign import setReferrerPolicy :: String -> HTMLImageElement -> Effect Unit
 
-foreign import decoding :: HTMLImageElement -> Effect String
-foreign import setDecoding :: String -> HTMLImageElement -> Effect Unit
+foreign import _decoding :: EffectFn1 HTMLImageElement String
 
-foreign import loading :: HTMLImageElement -> Effect String
-foreign import setLoading :: String -> HTMLImageElement -> Effect Unit
+decoding :: HTMLImageElement -> Effect DecodingHint
+decoding = map (fromMaybe DecodingHint.Auto <<< DecodingHint.parse) <<< runEffectFn1 _decoding
+
+foreign import _setDecoding :: EffectFn2 String HTMLImageElement Unit
+
+setDecoding :: DecodingHint -> HTMLImageElement -> Effect Unit
+setDecoding hint = runEffectFn2 _setDecoding (DecodingHint.print hint)
+
+foreign import _loading :: EffectFn1 HTMLImageElement String
+
+loading :: HTMLImageElement -> Effect Laziness
+loading = map (fromMaybe Laziness.Eager <<< Laziness.parse) <<< runEffectFn1 _loading
+
+foreign import _setLoading :: EffectFn2 String HTMLImageElement Unit
+
+setLoading :: Laziness -> HTMLImageElement -> Effect Unit
+setLoading laziness = runEffectFn2 _setLoading (Laziness.print laziness)
 
 foreign import complete :: HTMLImageElement -> Effect Boolean

--- a/src/Web/HTML/HTMLImageElement.purs
+++ b/src/Web/HTML/HTMLImageElement.purs
@@ -20,6 +20,9 @@ module Web.HTML.HTMLImageElement
   , setAlt
   , src
   , setSrc
+  , srcset
+  , setSrcset
+  , currentSrc
   , crossOrigin
   , setCrossOrigin
   , useMap
@@ -32,6 +35,12 @@ module Web.HTML.HTMLImageElement
   , setHeight
   , naturalWidth
   , naturalHeight
+  , referrerPolicy
+  , setReferrerPolicy
+  , decoding
+  , setDecoding
+  , loading
+  , setLoading
   , complete
   ) where
 
@@ -101,6 +110,14 @@ foreign import setAlt :: String -> HTMLImageElement -> Effect Unit
 foreign import src :: HTMLImageElement -> Effect String
 foreign import setSrc :: String -> HTMLImageElement -> Effect Unit
 
+foreign import srcset :: HTMLImageElement -> Effect String
+foreign import setSrcset :: String -> HTMLImageElement -> Effect Unit
+
+foreign import currentSrc :: HTMLImageElement -> Effect String
+
+foreign import sizes :: HTMLImageElement -> Effect String
+foreign import setSizes :: String -> HTMLImageElement -> Effect Unit
+
 foreign import crossOrigin :: HTMLImageElement -> Effect String
 foreign import setCrossOrigin :: String -> HTMLImageElement -> Effect Unit
 
@@ -118,4 +135,14 @@ foreign import setHeight :: Int -> HTMLImageElement -> Effect Unit
 
 foreign import naturalWidth :: HTMLImageElement -> Effect Int
 foreign import naturalHeight :: HTMLImageElement -> Effect Int
+
+foreign import referrerPolicy :: HTMLImageElement -> Effect String
+foreign import setReferrerPolicy :: String -> HTMLImageElement -> Effect Unit
+
+foreign import decoding :: HTMLImageElement -> Effect String
+foreign import setDecoding :: String -> HTMLImageElement -> Effect Unit
+
+foreign import loading :: HTMLImageElement -> Effect String
+foreign import setLoading :: String -> HTMLImageElement -> Effect Unit
+
 foreign import complete :: HTMLImageElement -> Effect Boolean

--- a/src/Web/HTML/HTMLImageElement/CORSMode.purs
+++ b/src/Web/HTML/HTMLImageElement/CORSMode.purs
@@ -1,0 +1,32 @@
+module Web.HTML.HTMLImageElement.CORSMode
+  ( CORSMode(..)
+  , parse
+  , print
+  ) where
+
+import Data.Maybe (Maybe(..))
+import Prelude (class Eq, class Ord, class Show)
+
+data CORSMode
+  = Anonymous
+  | UseCredentials 
+
+derive instance eqCORSMode :: Eq CORSMode
+derive instance ordCORSMode :: Ord CORSMode
+
+instance showDecodingHint :: Show CORSMode where
+  show = case _ of
+    Anonymous -> "Anonymous"
+    UseCredentials -> "UseCredentials"
+
+parse :: String -> Maybe CORSMode
+parse = case _ of
+  "" -> Just Anonymous
+  "anonymous" -> Just Anonymous
+  "use-credentials" -> Just UseCredentials
+  _ -> Nothing
+
+print :: CORSMode -> String
+print = case _ of
+  Anonymous -> "anonymous"
+  UseCredentials -> "use-credentials"

--- a/src/Web/HTML/HTMLImageElement/DecodingHint.purs
+++ b/src/Web/HTML/HTMLImageElement/DecodingHint.purs
@@ -1,0 +1,36 @@
+module Web.HTML.HTMLImageElement.DecodingHint
+  ( DecodingHint(..)
+  , parse
+  , print
+  ) where
+
+import Data.Maybe (Maybe(..))
+import Prelude (class Eq, class Ord, class Show)
+
+data DecodingHint
+  = Sync
+  | Async 
+  | Auto
+
+derive instance eqDecodingHint :: Eq DecodingHint
+derive instance ordDecodingHint :: Ord DecodingHint
+
+instance showDecodingHint :: Show DecodingHint where
+  show = case _ of
+    Sync -> "Sync"
+    Async -> "Async"
+    Auto -> "Auto"
+
+parse :: String -> Maybe DecodingHint
+parse = case _ of
+  "" -> Just Auto
+  "sync" -> Just Sync
+  "async" -> Just Async
+  "auto" -> Just Auto
+  _ -> Nothing
+
+print :: DecodingHint -> String
+print = case _ of
+  Sync -> "sync"
+  Async -> "async"
+  Auto -> "auto"

--- a/src/Web/HTML/HTMLImageElement/Laziness.purs
+++ b/src/Web/HTML/HTMLImageElement/Laziness.purs
@@ -1,0 +1,33 @@
+module Web.HTML.HTMLImageElement.Laziness
+  ( Laziness(..)
+  , parse
+  , print
+  ) where
+
+import Data.Maybe (Maybe(..))
+import Prelude (class Eq, class Ord, class Show)
+
+data Laziness
+  = Eager
+  | Lazy 
+
+derive instance eqDecodingHint :: Eq Laziness
+derive instance ordDecodingHint :: Ord Laziness
+
+instance showDecodingHint :: Show Laziness where
+  show = case _ of
+    Eager -> "Eager"
+    Lazy -> "Lazy"
+
+parse :: String -> Maybe Laziness
+parse = case _ of
+  "" -> Just Eager
+  "eager" -> Just Eager
+  "lazy" -> Just Lazy
+  _ -> Nothing
+
+
+print :: Laziness -> String
+print = case _ of
+  Eager -> "eager"
+  Lazy -> "lazy"


### PR DESCRIPTION
### Prerequisites

- [x] Before opening a pull request, please check the HTML standard (https://dom.spec.whatwg.org/). If it doesn't appear in this spec, it may be present in the spec for one of the other `purescript-web` projects. Although MDN is a great resource, it is not a suitable reference for this project.

### Description

Adding missing attributes for `HTMLImage`
https://html.spec.whatwg.org/multipage/embedded-content.html#dom-img-currentsrc

It would be nice to include [`decode()`](https://html.spec.whatwg.org/multipage/embedded-content.html#dom-img-decode), but since it returns a `Promise` and this project doesn't include `Aff`, I skipped it.
