### PR TITLE
window.devicePixelRatio

### DIFF
--- a/src/Web/HTML/Window.js
+++ b/src/Web/HTML/Window.js
@@ -176,6 +176,12 @@ exports.scrollY = function (window) {
   };
 };
 
+exports.devicePixelRatio = function(window) {
+  return function() {
+    return window.devicePixelRatio;
+  };
+};
+
 exports.localStorage = function (window) {
   return function () {
     return window.localStorage;

--- a/src/Web/HTML/Window.purs
+++ b/src/Web/HTML/Window.purs
@@ -25,6 +25,7 @@ module Web.HTML.Window
   , scrollBy
   , scrollX
   , scrollY
+  , devicePixelRatio
   , localStorage
   , sessionStorage
   , requestAnimationFrame
@@ -113,6 +114,8 @@ foreign import scrollBy :: Int -> Int -> Window -> Effect Unit
 foreign import scrollX :: Window -> Effect Int
 
 foreign import scrollY :: Window -> Effect Int
+
+foreign import devicePixelRatio :: Window -> Effect Number
 
 foreign import localStorage :: Window -> Effect Storage
 


### PR DESCRIPTION
### Prerequisites

- [ ] Before opening a pull request, please check the HTML standard (https://dom.spec.whatwg.org/). If it doesn't appear in this spec, it may be present in the spec for one of the other `purescript-web` projects. Although MDN is a great resource, it is not a suitable reference for this project.

### Description

According to [the spec](https://drafts.csswg.org/cssom-view/#dom-window-devicepixelratio), this, `devicePixelRatio`, is under CSSOM. There exists a `purescript-cssom` library, however, other functions like `scrollBy`, `scrollTo`, etc. are also listed under CSSOM, but are in the `Web.HTML` library so I guess this should go here??
