### PR TITLE
feat(#8): Add HTMLHyperlinkElementUtils module

### DIFF
--- a/src/Web/HTML/HTMLAnchorElement.purs
+++ b/src/Web/HTML/HTMLAnchorElement.purs
@@ -9,6 +9,7 @@ import Web.DOM.DOMTokenList (DOMTokenList)
 import Web.Event.EventTarget (EventTarget)
 import Web.HTML.HTMLElement (HTMLElement)
 import Web.Internal.FFI (unsafeReadProtoTagged)
+import Web.HTML.HTMLHyperlinkElementUtils (HTMLHyperlinkElementUtils)
 
 foreign import data HTMLAnchorElement :: Type
 
@@ -53,6 +54,9 @@ toParentNode = unsafeCoerce
 
 toEventTarget :: HTMLAnchorElement -> EventTarget
 toEventTarget = unsafeCoerce
+
+toHTMLHyperlinkElementUtils :: HTMLAnchorElement -> HTMLHyperlinkElementUtils
+toHTMLHyperlinkElementUtils = unsafeCoerce
 
 foreign import target :: HTMLAnchorElement -> Effect String
 foreign import setTarget :: String -> HTMLAnchorElement -> Effect Unit

--- a/src/Web/HTML/HTMLHyperlinkElementUtils.js
+++ b/src/Web/HTML/HTMLHyperlinkElementUtils.js
@@ -1,0 +1,167 @@
+"use strict";
+
+exports.href = function (u) {
+  return function () {
+    return u.href;
+  };
+};
+
+exports.setHref = function (href) {
+  return function (u) {
+    return function () {
+      u.href = href;
+    };
+  };
+};
+
+// ----------------------------------------------------------------------------
+
+exports.origin = function (u) {
+  return function () {
+    return u.origin;
+  };
+};
+
+// ----------------------------------------------------------------------------
+
+exports.protocol = function (u) {
+  return function () {
+    return u.protocol;
+  };
+};
+
+exports.setProtocol = function (protocol) {
+  return function (u) {
+    return function () {
+      u.protocol = protocol;
+    };
+  };
+};
+
+// ----------------------------------------------------------------------------
+
+exports.username = function (u) {
+  return function () {
+    return u.username;
+  };
+};
+
+exports.setUsername = function (username) {
+  return function (u) {
+    return function () {
+      u.username = username;
+    };
+  };
+};
+
+// ----------------------------------------------------------------------------
+
+exports.password = function (u) {
+  return function () {
+    return u.password;
+  };
+};
+
+exports.setPassword = function (password) {
+  return function (u) {
+    return function () {
+      u.password = password;
+    };
+  };
+};
+
+// ----------------------------------------------------------------------------
+
+exports.host = function (u) {
+  return function () {
+    return u.host;
+  };
+};
+
+exports.setHost = function (host) {
+  return function (u) {
+    return function () {
+      u.host = host;
+    };
+  };
+};
+
+// ----------------------------------------------------------------------------
+
+exports.hostname = function (u) {
+  return function () {
+    return u.hostname;
+  };
+};
+
+exports.setHostname = function (hostname) {
+  return function (u) {
+    return function () {
+      u.hostname = hostname;
+    };
+  };
+};
+
+// ----------------------------------------------------------------------------
+
+exports.port = function (u) {
+  return function () {
+    return u.port;
+  };
+};
+
+exports.setPort = function (port) {
+  return function (u) {
+    return function () {
+      u.port = port;
+    };
+  };
+};
+
+// ----------------------------------------------------------------------------
+
+exports.pathname = function (u) {
+  return function () {
+    return u.pathname;
+  };
+};
+
+exports.setPathname = function (pathname) {
+  return function (u) {
+    return function () {
+      u.pathname = pathname;
+    };
+  };
+};
+
+// ----------------------------------------------------------------------------
+
+exports.search = function (u) {
+  return function () {
+    return u.search;
+  };
+};
+
+exports.setSearch = function (search) {
+  return function (u) {
+    return function () {
+      u.search = search;
+    };
+  };
+};
+
+// ----------------------------------------------------------------------------
+
+exports.hash = function (u) {
+  return function () {
+    return u.hash;
+  };
+};
+
+exports.setHash = function (hash) {
+  return function (u) {
+    return function () {
+      u.hash = hash;
+    };
+  };
+};

--- a/src/Web/HTML/HTMLHyperlinkElementUtils.purs
+++ b/src/Web/HTML/HTMLHyperlinkElementUtils.purs
@@ -1,0 +1,39 @@
+-- https://html.spec.whatwg.org/multipage/links.html#htmlhyperlinkelementutils
+module Web.HTML.HTMLHyperlinkElementUtils where
+
+import Effect (Effect)
+import Prelude (Unit)
+
+foreign import data HTMLHyperlinkElementUtils :: Type
+
+foreign import href :: HTMLHyperlinkElementUtils -> Effect String
+foreign import setHref :: String -> HTMLHyperlinkElementUtils -> Effect Unit
+
+foreign import origin :: HTMLHyperlinkElementUtils -> Effect String
+
+foreign import protocol :: HTMLHyperlinkElementUtils -> Effect String
+foreign import setProtocol :: String -> HTMLHyperlinkElementUtils -> Effect Unit
+
+foreign import username :: HTMLHyperlinkElementUtils -> Effect String
+foreign import setUsername :: String -> HTMLHyperlinkElementUtils -> Effect Unit
+
+foreign import password :: HTMLHyperlinkElementUtils -> Effect String
+foreign import setPassword :: String -> HTMLHyperlinkElementUtils -> Effect Unit
+
+foreign import host :: HTMLHyperlinkElementUtils -> Effect String
+foreign import setHost :: String -> HTMLHyperlinkElementUtils -> Effect Unit
+
+foreign import hostname :: HTMLHyperlinkElementUtils -> Effect String
+foreign import setHostname :: String -> HTMLHyperlinkElementUtils -> Effect Unit
+
+foreign import port :: HTMLHyperlinkElementUtils -> Effect String
+foreign import setPort :: String -> HTMLHyperlinkElementUtils -> Effect Unit
+
+foreign import pathname :: HTMLHyperlinkElementUtils -> Effect String
+foreign import setPathname :: String -> HTMLHyperlinkElementUtils -> Effect Unit
+
+foreign import search :: HTMLHyperlinkElementUtils -> Effect String
+foreign import setSearch :: String -> HTMLHyperlinkElementUtils -> Effect Unit
+
+foreign import hash :: HTMLHyperlinkElementUtils -> Effect String
+foreign import setHash :: String -> HTMLHyperlinkElementUtils -> Effect Unit


### PR DESCRIPTION
### Prerequisites

- [x] Before opening a pull request, please check the HTML standard (https://dom.spec.whatwg.org/). If it doesn't appear in this spec, it may be present in the spec for one of the other `purescript-web` projects. Although MDN is a great resource, it is not a suitable reference for this project.

### Description

Add HTMLHyperlinkElementUtils module

Fixes https://github.com/purescript-web/purescript-web-html/issues/8