### PR TITLE
Remove Unit argument from create functions.

### DIFF
--- a/src/Web/HTML/HTMLAudioElement.js
+++ b/src/Web/HTML/HTMLAudioElement.js
@@ -1,9 +1,7 @@
 "use strict";
 
 exports.create = function () {
-  return function () {
-    return new Audio();
-  };
+  return new Audio();
 };
 
 exports.createWithURL = function (url) {

--- a/src/Web/HTML/HTMLAudioElement.purs
+++ b/src/Web/HTML/HTMLAudioElement.purs
@@ -21,7 +21,6 @@ module Web.HTML.HTMLAudioElement
 
 import Data.Maybe (Maybe)
 import Effect (Effect)
-import Prelude (Unit)
 import Unsafe.Coerce (unsafeCoerce)
 import Web.DOM (ChildNode, Element, Node, NonDocumentTypeChildNode, ParentNode)
 import Web.Event.EventTarget (EventTarget)

--- a/src/Web/HTML/HTMLAudioElement.purs
+++ b/src/Web/HTML/HTMLAudioElement.purs
@@ -1,4 +1,4 @@
-module Web.HTML.HTMLAudioElement 
+module Web.HTML.HTMLAudioElement
   ( HTMLAudioElement
   , fromHTMLElement
   , fromElement
@@ -79,7 +79,7 @@ toParentNode = unsafeCoerce
 toEventTarget :: HTMLAudioElement -> EventTarget
 toEventTarget = unsafeCoerce
 
-foreign import create :: Unit -> Effect HTMLAudioElement
+foreign import create :: Effect HTMLAudioElement
 foreign import createWithURL :: String -> Effect HTMLAudioElement
 
 create' :: String -> Effect HTMLAudioElement

--- a/src/Web/HTML/HTMLImageElement.js
+++ b/src/Web/HTML/HTMLImageElement.js
@@ -1,9 +1,7 @@
 "use strict";
 
 exports.create = function () {
-  return function () {
-    return new Image();
-  };
+  return new Image();
 };
 
 exports.createWithDimensions = function (width) {
@@ -189,7 +187,6 @@ exports.setReferrerPolicy = function (referrerPolicy) {
     };
   };
 };
-
 
 // ----------------------------------------------------------------------------
 

--- a/src/Web/HTML/HTMLImageElement.purs
+++ b/src/Web/HTML/HTMLImageElement.purs
@@ -108,8 +108,7 @@ toParentNode = unsafeCoerce
 toEventTarget :: HTMLImageElement -> EventTarget
 toEventTarget = unsafeCoerce
 
-
-foreign import create :: Unit -> Effect HTMLImageElement
+foreign import create :: Effect HTMLImageElement
 foreign import createWithDimensions :: Int -> Int -> Effect HTMLImageElement
 
 create' :: Int -> Int -> Effect HTMLImageElement


### PR DESCRIPTION
As discussed in https://github.com/purescript-web/purescript-web-html/pull/32#discussion_r541469627, the `create` functions implemented in `HTMLAudioElement` and `HTMLImageElement` take an unnecessary unit argument. This commit updates the FFI and PureScript code to remove this argument.

cc: @garyb 