### PR TITLE
Add fromEventTarget to Window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Notable changes to this project are documented in this file. The format is based
 Breaking changes:
 
 New features:
+- Added `fromEventTarget` function for `Window` (#53 by @thomashoneyman)
 
 Bugfixes:
 

--- a/src/Web/HTML/Window.purs
+++ b/src/Web/HTML/Window.purs
@@ -1,6 +1,7 @@
 module Web.HTML.Window
   ( Window
   , toEventTarget
+  , fromEventTarget
   , document
   , navigator
   , location
@@ -48,6 +49,7 @@ import Web.HTML.History (History)
 import Web.HTML.Location (Location)
 import Web.HTML.Navigator (Navigator)
 import Web.Storage.Storage (Storage)
+import Web.Internal.FFI (unsafeReadProtoTagged)
 
 foreign import data Window :: Type
 

--- a/src/Web/HTML/Window.purs
+++ b/src/Web/HTML/Window.purs
@@ -54,6 +54,9 @@ foreign import data Window :: Type
 toEventTarget :: Window -> EventTarget
 toEventTarget = unsafeCoerce
 
+fromEventTarget :: EventTarget -> Maybe Window
+fromEventTarget = unsafeReadProtoTagged "Window"
+
 foreign import document :: Window -> Effect HTMLDocument
 
 foreign import navigator :: Window -> Effect Navigator


### PR DESCRIPTION
**Prerequisites**

- [x] Before opening a pull request, please check the HTML standard (https://dom.spec.whatwg.org/). If it doesn't appear in this spec, it may be present in the spec for one of the other `purescript-web` projects. Although MDN is a great resource, it is not a suitable reference for this project.

**Description of the change**

Closes #28 by adding a `fromEventTarget` function.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- ~Updated or added relevant documentation~
- ~Added a test for the contribution (if applicable)~
