### PR TITLE
Add DataTransferItem and related API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Notable changes to this project are documented in this file. The format is based
 Breaking changes:
 
 New features:
+- Added `items` function for `DataTransfer` and related types (`DataTransferItem`, `DataTransferItemList`) (#55 by @ptrfrncsmrph)
 
 Bugfixes:
 

--- a/src/Web/HTML/Event/DataTransfer.js
+++ b/src/Web/HTML/Event/DataTransfer.js
@@ -4,6 +4,10 @@ exports._files = function (dataTransfer) {
   return dataTransfer.files;
 };
 
+exports.items = function (dataTransfer) {
+  return dataTransfer.items;
+};
+
 exports.types = function (dataTransfer) {
   return dataTransfer.types;
 };

--- a/src/Web/HTML/Event/DataTransfer.purs
+++ b/src/Web/HTML/Event/DataTransfer.purs
@@ -1,6 +1,7 @@
 module Web.HTML.Event.DataTransfer
   ( DataTransfer
   , files
+  , items
   , types
   , getData
   , setData

--- a/src/Web/HTML/Event/DataTransfer.purs
+++ b/src/Web/HTML/Event/DataTransfer.purs
@@ -16,6 +16,7 @@ import Data.MediaType (MediaType(..))
 import Data.Nullable (Nullable, toMaybe)
 import Effect (Effect)
 import Web.File.FileList (FileList)
+import Web.HTML.Event.DataTransfer.DataTransferItem (DataTransferItemList)
 
 foreign import data DataTransfer :: Type
 
@@ -28,6 +29,10 @@ files :: DataTransfer -> Maybe FileList
 files = toMaybe <$> _files
 
 foreign import _files :: DataTransfer -> Nullable FileList
+
+-- | Returns a `DataTransferItemList` object which is a list of all of the drag
+-- | data.
+foreign import items :: DataTransfer -> DataTransferItemList
 
 -- | Returns an array of data formats used in the drag operation.
 -- | If the drag operation included no data, then the array is empty.

--- a/src/Web/HTML/Event/DataTransfer/DataTransferItem.js
+++ b/src/Web/HTML/Event/DataTransfer/DataTransferItem.js
@@ -1,0 +1,19 @@
+"use strict";
+
+exports.kind = function (dataTransferItem) {
+  return dataTransferItem.kind;
+};
+
+exports.type_ = function (dataTransferItem) {
+  return dataTransferItem.type;
+};
+
+exports._dataTransferItem = function (index) {
+  return function (dataTransferItemList) {
+    return dataTransferItemList[index];
+  };
+};
+
+exports._length = function (dataTransferItemList) {
+  return dataTransferItemList.length;
+};

--- a/src/Web/HTML/Event/DataTransfer/DataTransferItem.js
+++ b/src/Web/HTML/Event/DataTransfer/DataTransferItem.js
@@ -1,7 +1,11 @@
 "use strict";
 
-exports.kind = function (dataTransferItem) {
-  return dataTransferItem.kind;
+exports._kind = function (text, file, dataTransferItem) {
+  if (dataTransferItem.kind === "string") {
+    return text;
+  } else {
+    return file;
+  }
 };
 
 exports.type_ = function (dataTransferItem) {

--- a/src/Web/HTML/Event/DataTransfer/DataTransferItem.js
+++ b/src/Web/HTML/Event/DataTransfer/DataTransferItem.js
@@ -1,10 +1,12 @@
 "use strict";
 
-exports._kind = function (text, file, dataTransferItem) {
+exports._kind = function (nothing, just, text, file, dataTransferItem) {
   if (dataTransferItem.kind === "string") {
-    return text;
+    return just(text);
+  } else if (dataTransferItem.kind === "file") {
+    return just(file);
   } else {
-    return file;
+    return nothing;
   }
 };
 

--- a/src/Web/HTML/Event/DataTransfer/DataTransferItem.purs
+++ b/src/Web/HTML/Event/DataTransfer/DataTransferItem.purs
@@ -1,15 +1,36 @@
 module Web.HTML.Event.DataTransfer.DataTransferItem
   ( DataTransferItem
+  , DataTransferItemKind(..)
   , DataTransferItemList
+  , dataTransferItem
+  , kind
+  , length
+  , type_
   ) where
 
 import Prelude
+
+import Data.Function.Uncurried (Fn3)
+import Data.Function.Uncurried as Uncurried
 import Data.Maybe (Maybe)
 import Data.Nullable (Nullable)
 import Data.Nullable as Nullable
 
+data DataTransferItemKind = Text | File
+
+derive instance Eq DataTransferItemKind
+derive instance Ord DataTransferItemKind
+
+instance Show DataTransferItemKind where
+  show = case _ of
+    Text -> "Text"
+    File -> "File"
+
 -- | Returns the drag data item kind, which is either "string" or "file".
-foreign import kind :: DataTransferItem -> String
+kind :: DataTransferItem -> DataTransferItemKind
+kind = Uncurried.runFn3 _kind Text File
+
+foreign import _kind :: Fn3 DataTransferItemKind DataTransferItemKind DataTransferItem DataTransferItemKind
 
 -- | A Unicode string giving the type or format of the data, generally given by
 -- | a MIME type. Some values that are not MIME types are special-cased for

--- a/src/Web/HTML/Event/DataTransfer/DataTransferItem.purs
+++ b/src/Web/HTML/Event/DataTransfer/DataTransferItem.purs
@@ -26,11 +26,11 @@ instance Show DataTransferItemKind where
     Text -> "Text"
     File -> "File"
 
+foreign import _kind :: Fn3 DataTransferItemKind DataTransferItemKind DataTransferItem DataTransferItemKind
+
 -- | Returns the drag data item kind, which is either "string" or "file".
 kind :: DataTransferItem -> DataTransferItemKind
 kind = Uncurried.runFn3 _kind Text File
-
-foreign import _kind :: Fn3 DataTransferItemKind DataTransferItemKind DataTransferItem DataTransferItemKind
 
 -- | A Unicode string giving the type or format of the data, generally given by
 -- | a MIME type. Some values that are not MIME types are special-cased for
@@ -40,16 +40,16 @@ foreign import _kind :: Fn3 DataTransferItemKind DataTransferItemKind DataTransf
 -- | There is a limit of one text item per item type string.
 foreign import type_ :: DataTransferItem -> String
 
+foreign import _dataTransferItem :: Int -> DataTransferItemList -> Nullable DataTransferItem
+
 -- | Access an item in the `DataTransferItemList` by index.
 dataTransferItem :: Int -> DataTransferItemList -> Maybe DataTransferItem
 dataTransferItem = map Nullable.toMaybe <$> _dataTransferItem
 
-foreign import _dataTransferItem :: Int -> DataTransferItemList -> Nullable DataTransferItem
+foreign import _length :: DataTransferItemList -> Int
 
 length :: DataTransferItemList -> Int
 length = _length
-
-foreign import _length :: DataTransferItemList -> Int
 
 foreign import data DataTransferItem :: Type
 

--- a/src/Web/HTML/Event/DataTransfer/DataTransferItem.purs
+++ b/src/Web/HTML/Event/DataTransfer/DataTransferItem.purs
@@ -1,0 +1,35 @@
+module Web.HTML.Event.DataTransfer.DataTransferItem
+  ( DataTransferItem
+  , DataTransferItemList
+  ) where
+
+import Prelude
+import Data.Maybe (Maybe)
+import Data.Nullable (Nullable)
+import Data.Nullable as Nullable
+
+-- | Returns the drag data item kind, which is either "string" or "file".
+foreign import kind :: DataTransferItem -> String
+
+-- | A Unicode string giving the type or format of the data, generally given by
+-- | a MIME type. Some values that are not MIME types are special-cased for
+-- | legacy reasons. The API does not enforce the use of MIME types; other
+-- | values can be used as well. In all cases, however, the values are all
+-- | converted to ASCII lowercase by the API.
+-- | There is a limit of one text item per item type string.
+foreign import type_ :: DataTransferItem -> String
+
+-- | Access an item in the `DataTransferItemList` by index.
+dataTransferItem :: Int -> DataTransferItemList -> Maybe DataTransferItem
+dataTransferItem = map Nullable.toMaybe <$> _dataTransferItem
+
+foreign import _dataTransferItem :: Int -> DataTransferItemList -> Nullable DataTransferItem
+
+length :: DataTransferItemList -> Int
+length = _length
+
+foreign import _length :: DataTransferItemList -> Int
+
+foreign import data DataTransferItem :: Type
+
+foreign import data DataTransferItemList :: Type

--- a/src/Web/HTML/Event/DataTransfer/DataTransferItem.purs
+++ b/src/Web/HTML/Event/DataTransfer/DataTransferItem.purs
@@ -10,9 +10,9 @@ module Web.HTML.Event.DataTransfer.DataTransferItem
 
 import Prelude
 
-import Data.Function.Uncurried (Fn3)
+import Data.Function.Uncurried (Fn5)
 import Data.Function.Uncurried as Uncurried
-import Data.Maybe (Maybe)
+import Data.Maybe (Maybe(..))
 import Data.Nullable (Nullable)
 import Data.Nullable as Nullable
 
@@ -26,11 +26,19 @@ instance Show DataTransferItemKind where
     Text -> "Text"
     File -> "File"
 
-foreign import _kind :: Fn3 DataTransferItemKind DataTransferItemKind DataTransferItem DataTransferItemKind
+foreign import _kind
+  :: Fn5 (forall x. Maybe x)
+       (forall x. x -> Maybe x)
+       DataTransferItemKind
+       DataTransferItemKind
+       DataTransferItem
+       (Maybe DataTransferItemKind)
 
--- | Returns the drag data item kind, which is either "string" or "file".
-kind :: DataTransferItem -> DataTransferItemKind
-kind = Uncurried.runFn3 _kind Text File
+-- | Returns the drag data item kind of the `DataTransferItem`. In the case
+-- | where the `DataTransferItem` object is in _disabled mode_, `Nothing` is
+-- | returned.
+kind :: DataTransferItem -> Maybe DataTransferItemKind
+kind = Uncurried.runFn5 _kind Nothing Just Text File
 
 -- | A Unicode string giving the type or format of the data, generally given by
 -- | a MIME type. Some values that are not MIME types are special-cased for


### PR DESCRIPTION
**Prerequisites**

- [x] Before opening a pull request, please check the HTML standard (https://dom.spec.whatwg.org/). If it doesn't appear in this spec, it may be present in the spec for one of the other `purescript-web` projects. Although MDN is a great resource, it is not a suitable reference for this project.


**Description of the change**

Fixes: #54 

This would add support `DataTransfer.items` (HTML spec reference [here](https://html.spec.whatwg.org/#dom-datatransfer-items), MDN docs [here](https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer/items))

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
