### PR TITLE
Add navigator.languages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Notable changes to this project are documented in this file. The format is based
 Breaking changes:
 
 New features:
+- Added `languages` value for `Navigator` (#59 by @toastal)
 
 Bugfixes:
 

--- a/src/Web/HTML/Navigator.js
+++ b/src/Web/HTML/Navigator.js
@@ -6,6 +6,12 @@ exports.language = function (navigator) {
   };
 };
 
+exports.languages = function (navigator) {
+  return function () {
+    return navigator.languages;
+  };
+};
+
 exports.platform = function (navigator) {
   return function () {
     return navigator.platform;

--- a/src/Web/HTML/Navigator.purs
+++ b/src/Web/HTML/Navigator.purs
@@ -6,6 +6,8 @@ foreign import data Navigator :: Type
 
 foreign import language :: Navigator -> Effect String
 
+foreign import languages :: Navigator -> Effect (Array String)
+
 foreign import platform :: Navigator -> Effect String
 
 foreign import userAgent :: Navigator -> Effect String


### PR DESCRIPTION
**Prerequisites**

- [x] Before opening a pull request, please check the HTML standard (https://dom.spec.whatwg.org/). If it doesn't appear in this spec, it may be present in the spec for one of the other `purescript-web` projects. Although MDN is a great resource, it is not a suitable reference for this project.

Found it: https://html.spec.whatwg.org/multipage/system-state.html#language-preferences
It appears all of the `Navigator` needs to be updated on MDN.

**Description of the change**

Languages, plural, gives the developer a list of languages the use prefers be the fallback. Personally I'd rather fallback from `en-US` to `en-CA` instead of `en-GB` and would take Spanish before French and this feature lets users tell the application their preferences (sadly at the cost of browser fingerprinting). This list is also the same list for the `Accept-Language` HTTP header the client sends to the server, but maybe a SPA would want to know as well since it will talk to the server a lot less.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)
