### PR TITLE
Add HTMLHtmlElement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Notable changes to this project are documented in this file. The format is based
 Breaking changes:
 
 New features:
+- Added `HTMLHtmlElement` module and `documentElement` function `HTMLDocument` (#60 by @toastal)
 
 Bugfixes:
 

--- a/src/Web/HTML/HTMLDocument.js
+++ b/src/Web/HTML/HTMLDocument.js
@@ -1,5 +1,11 @@
 "use strict";
 
+exports._documentElement = function (doc) {
+  return function () {
+    return doc.documentElement;
+  };
+};
+
 exports._head = function (doc) {
   return function () {
     return doc.head;

--- a/src/Web/HTML/HTMLDocument.purs
+++ b/src/Web/HTML/HTMLDocument.purs
@@ -10,6 +10,7 @@ module Web.HTML.HTMLDocument
   , toParentNode
   , toNonElementParentNode
   , toEventTarget
+  , documentElement
   , head
   , body
   , readyState
@@ -34,6 +35,7 @@ import Web.Event.EventTarget (EventTarget)
 import Web.HTML.HTMLDocument.ReadyState (ReadyState)
 import Web.HTML.HTMLDocument.ReadyState as ReadyState
 import Web.HTML.HTMLElement (HTMLElement)
+import Web.HTML.HTMLHtmlElement (HTMLHtmlElement)
 import Web.HTML.HTMLScriptElement (HTMLScriptElement)
 import Web.Internal.FFI (unsafeReadProtoTagged)
 
@@ -68,6 +70,11 @@ toNonElementParentNode = unsafeCoerce
 
 toEventTarget :: HTMLDocument -> EventTarget
 toEventTarget = unsafeCoerce
+
+foreign import _documentElement :: HTMLDocument -> Effect (Nullable HTMLHtmlElement)
+
+documentElement :: HTMLDocument -> Effect (Maybe HTMLHtmlElement)
+documentElement = map toMaybe <<< _documentElement
 
 foreign import _head :: HTMLDocument -> Effect (Nullable HTMLElement)
 

--- a/src/Web/HTML/HTMLHtmlElement.purs
+++ b/src/Web/HTML/HTMLHtmlElement.purs
@@ -1,0 +1,52 @@
+module Web.HTML.HTMLHtmlElement where
+
+import Data.Maybe (Maybe)
+import Unsafe.Coerce (unsafeCoerce)
+import Web.DOM (ChildNode, Element, Node, NonDocumentTypeChildNode, ParentNode)
+import Web.Event.EventTarget (EventTarget)
+import Web.HTML.HTMLElement (HTMLElement)
+import Web.Internal.FFI (unsafeReadProtoTagged)
+
+foreign import data HTMLHtmlElement :: Type
+
+fromHTMLElement :: HTMLElement -> Maybe HTMLHtmlElement
+fromHTMLElement = unsafeReadProtoTagged "HTMLHtmlElement"
+
+fromElement :: Element -> Maybe HTMLHtmlElement
+fromElement = unsafeReadProtoTagged "HTMLHtmlElement"
+
+fromNode :: Node -> Maybe HTMLHtmlElement
+fromNode = unsafeReadProtoTagged "HTMLHtmlElement"
+
+fromChildNode :: ChildNode -> Maybe HTMLHtmlElement
+fromChildNode = unsafeReadProtoTagged "HTMLHtmlElement"
+
+fromNonDocumentTypeChildNode :: NonDocumentTypeChildNode -> Maybe HTMLHtmlElement
+fromNonDocumentTypeChildNode = unsafeReadProtoTagged "HTMLHtmlElement"
+
+fromParentNode :: ParentNode -> Maybe HTMLHtmlElement
+fromParentNode = unsafeReadProtoTagged "HTMLHtmlElement"
+
+fromEventTarget :: EventTarget -> Maybe HTMLHtmlElement
+fromEventTarget = unsafeReadProtoTagged "HTMLHtmlElement"
+
+toHTMLElement :: HTMLHtmlElement -> HTMLElement
+toHTMLElement = unsafeCoerce
+
+toElement :: HTMLHtmlElement -> Element
+toElement = unsafeCoerce
+
+toNode :: HTMLHtmlElement -> Node
+toNode = unsafeCoerce
+
+toChildNode :: HTMLHtmlElement -> ChildNode
+toChildNode = unsafeCoerce
+
+toNonDocumentTypeChildNode :: HTMLHtmlElement -> NonDocumentTypeChildNode
+toNonDocumentTypeChildNode = unsafeCoerce
+
+toParentNode :: HTMLHtmlElement -> ParentNode
+toParentNode = unsafeCoerce
+
+toEventTarget :: HTMLHtmlElement -> EventTarget
+toEventTarget = unsafeCoerce


### PR DESCRIPTION
**Prerequisites**

- [x] Before opening a pull request, please check the HTML standard (https://dom.spec.whatwg.org/). If it doesn't appear in this spec, it may be present in the spec for one of the other `purescript-web` projects. Although MDN is a great resource, it is not a suitable reference for this project.

https://html.spec.whatwg.org/multipage/semantics.html#htmlhtmlelement
https://developer.mozilla.org/en-US/docs/Web/API/HTMLHtmlElement
```javascript
console.assert(document.documentElement instanceof HTMLHtmlElement) // true
```


**Description of the change**

Terribly named, the `HTMLHtmlElement` is the element for `<html>`. I'm surprised this was missing. Implementing, I copied `HTMLBodyElement` because it too doesn't have any special properties. And I checked, though a bit nonsensical, this should be `NonDocumentTypeChildNode` because the element does have an always-`null`-returning `nextElementSibling` (its `parentNode`, `HTMLDocument` does not).

I need this for work because I need to get `document.documentElement`.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)
