### PR TITLE
Add Navigator.onLine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Breaking changes:
 New features:
 - Added `languages` value for `Navigator` (#59 by @toastal)
 - Added `HTMLHtmlElement` module and `documentElement` function `HTMLDocument` (#60 by @toastal)
+- Added `onLine` value for `Navigator` (#61 by @toastal)
 
 Bugfixes:
 

--- a/src/Web/HTML/Navigator.js
+++ b/src/Web/HTML/Navigator.js
@@ -12,6 +12,12 @@ exports.languages = function (navigator) {
   };
 };
 
+exports.onLine = function (navigator) {
+  return function () {
+    return navigator.onLine;
+  };
+};
+
 exports.platform = function (navigator) {
   return function () {
     return navigator.platform;

--- a/src/Web/HTML/Navigator.purs
+++ b/src/Web/HTML/Navigator.purs
@@ -8,6 +8,8 @@ foreign import language :: Navigator -> Effect String
 
 foreign import languages :: Navigator -> Effect (Array String)
 
+foreign import onLine :: Navigator -> Effect Boolean
+
 foreign import platform :: Navigator -> Effect String
 
 foreign import userAgent :: Navigator -> Effect String


### PR DESCRIPTION
**Prerequisites**

- [x] Before opening a pull request, please check the HTML standard (https://dom.spec.whatwg.org/). If it doesn't appear in this spec, it may be present in the spec for one of the other `purescript-web` projects. Although MDN is a great resource, it is not a suitable reference for this project.

https://html.spec.whatwg.org/multipage/system-state.html#dom-navigator-online-dev

**Description of the change**

While not [100% reliable](https://www.html5rocks.com/en/mobile/workingoffthegrid/), this can be used as a part of a whole related to getting the *real* connectivity status of the browser.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)
