### PR TITLE
Add DataTransfer.setDragImage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ New features:
 - Added `languages` value for `Navigator` (#59 by @toastal)
 - Added `HTMLHtmlElement` module and `documentElement` function `HTMLDocument` (#60 by @toastal)
 - Added `onLine` value for `Navigator` (#61 by @toastal)
+- Added `setDragImage` function for `DataTransfer` (#65 by @ajarista)
 
 Bugfixes:
 

--- a/src/Web/HTML/Event/DataTransfer.js
+++ b/src/Web/HTML/Event/DataTransfer.js
@@ -26,6 +26,18 @@ exports._setData = function (format) {
   };
 };
 
+exports._setDragImage = function (dataTransfer) {
+  return function (image) {
+    return function (x) {
+      return function (y) {
+        return function () {
+          return dataTransfer.setDragImage(image, x, y);
+        };
+      };
+    };
+  };
+};
+
 exports._dropEffect = function (dataTransfer) {
   return function () {
     return dataTransfer.dropEffect;

--- a/src/Web/HTML/Event/DataTransfer.purs
+++ b/src/Web/HTML/Event/DataTransfer.purs
@@ -59,14 +59,13 @@ setData
   -> Effect Unit
 setData (MediaType format) dat dt = _setData format dat dt
 
+foreign import _setDragImage :: DataTransfer -> Element -> Int -> Int -> Effect Unit
+
 -- | Sets the image to be used for dragging if a custom one is desired.
 -- | The image will typically be an <image> but could be any other *visible* element.
 -- | The x and y coordinates define where the image appears relative to the mouse.
 setDragImage :: DataTransfer -> Element -> Int -> Int -> Effect Unit
 setDragImage = _setDragImage
-
-foreign import _setDragImage :: DataTransfer -> Element -> Int -> Int -> Effect Unit
-
 foreign import _dropEffect :: DataTransfer -> Effect String
 
 data DropEffect = Copy | Link | Move | None

--- a/src/Web/HTML/Event/DataTransfer.purs
+++ b/src/Web/HTML/Event/DataTransfer.purs
@@ -4,6 +4,7 @@ module Web.HTML.Event.DataTransfer
   , types
   , getData
   , setData
+  , setDragImage
   , DropEffect(..)
   , dropEffect
   , setDropEffect
@@ -15,6 +16,7 @@ import Data.Maybe (Maybe)
 import Data.MediaType (MediaType(..))
 import Data.Nullable (Nullable, toMaybe)
 import Effect (Effect)
+import Web.DOM.Element (Element)
 import Web.File.FileList (FileList)
 
 foreign import data DataTransfer :: Type
@@ -56,6 +58,14 @@ setData
   -> DataTransfer
   -> Effect Unit
 setData (MediaType format) dat dt = _setData format dat dt
+
+-- | Sets the image to be used for dragging if a custom one is desired.
+-- | The image will typically be an <image> but could be any other *visible* element.
+-- | The x and y coordinates define where the image appears relative to the mouse.
+setDragImage :: DataTransfer -> Element -> Int -> Int -> Effect Unit
+setDragImage = _setDragImage
+
+foreign import _setDragImage :: DataTransfer -> Element -> Int -> Int -> Effect Unit
 
 foreign import _dropEffect :: DataTransfer -> Effect String
 


### PR DESCRIPTION
**Prerequisites**

- [x] Before opening a pull request, please check the HTML standard (https://dom.spec.whatwg.org/). If it doesn't appear in this spec, it may be present in the spec for one of the other `purescript-web` projects. Although MDN is a great resource, it is not a suitable reference for this project.

**Description of the change**
Adds the DataTransfer.setDragImage API function. As described here - https://html.spec.whatwg.org/multipage/dnd.html#the-datatransfer-interface.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)
