### PR TITLE
Remove duplicate cells export from HTMLTableRowElement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ New features:
 - Added `onLine` value for `Navigator` (#61 by @toastal)
 - Added `setDragImage` function for `DataTransfer` (#65 by @ajarista)
 
+Bugfixes:
+- Removed duplicated `cells` export from the FFI in HTMLTableRowElement.js (#58 by @thomashoneyman)
+
 ## [v3.1.0](https://github.com/purescript-web/purescript-web-html/releases/tag/v3.1.0) - 2021-05-06
 
 New features:

--- a/src/Web/HTML/HTMLTableRowElement.js
+++ b/src/Web/HTML/HTMLTableRowElement.js
@@ -24,14 +24,6 @@ exports.cells = function (row) {
 
 // ----------------------------------------------------------------------------
 
-exports.cells = function (row) {
-  return function () {
-    return row.cells;
-  };
-};
-
-// ----------------------------------------------------------------------------
-
 exports.insertCellAt = function (index) {
   return function (row) {
     return function () {


### PR DESCRIPTION
**Description of the change**

Closes #58 by removing a duplicated FFI export of the `cells` function.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- ~Updated or added relevant documentation~
- ~Added a test for the contribution (if applicable)~
