### PR TITLE
Add instance names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Breaking changes:
 New features:
 
 Bugfixes:
+- Added missing type class instance names for `DataTransferItemKind` (#69 by @ptrfrncsmrph)
 
 Other improvements:
 

--- a/src/Web/HTML/Event/DataTransfer/DataTransferItem.purs
+++ b/src/Web/HTML/Event/DataTransfer/DataTransferItem.purs
@@ -18,10 +18,10 @@ import Data.Nullable as Nullable
 
 data DataTransferItemKind = Text | File
 
-derive instance Eq DataTransferItemKind
-derive instance Ord DataTransferItemKind
+derive instance eqDataTransferItemKind :: Eq DataTransferItemKind
+derive instance ordDataTransferItemKind :: Ord DataTransferItemKind
 
-instance Show DataTransferItemKind where
+instance showDataTransferItemKind :: Show DataTransferItemKind where
   show = case _ of
     Text -> "Text"
     File -> "File"


### PR DESCRIPTION
**Prerequisites**

- [x] Before opening a pull request, please check the HTML standard (https://dom.spec.whatwg.org/). If it doesn't appear in this spec, it may be present in the spec for one of the other `purescript-web` projects. Although MDN is a great resource, it is not a suitable reference for this project.


**Description of the change**

Fixes #68. Adds missing type class instance names for `DataTransferItemKind`.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
