### PR TITLE
Fix broken window export, causing the function to return itself

### DIFF
--- a/src/Web/HTML.js
+++ b/src/Web/HTML.js
@@ -1,4 +1,4 @@
-const windowImpl = function() {
-  return window;
+const windowImpl = function () {
+  return window
 }
-export {windowImpl as window};
+export { windowImpl as window }

--- a/src/Web/HTML.js
+++ b/src/Web/HTML.js
@@ -1,3 +1,3 @@
-export function window() {
+export function windowImpl() {
   return window;
 }

--- a/src/Web/HTML.js
+++ b/src/Web/HTML.js
@@ -1,3 +1,4 @@
-export function windowImpl() {
+const windowImpl = function() {
   return window;
 }
+export {windowImpl as window};

--- a/src/Web/HTML.js
+++ b/src/Web/HTML.js
@@ -1,4 +1,4 @@
 const windowImpl = function () {
-  return window
-}
-export { windowImpl as window }
+  return window;
+};
+export { windowImpl as window };

--- a/src/Web/HTML.purs
+++ b/src/Web/HTML.purs
@@ -74,7 +74,4 @@ import Web.HTML.Location (Location) as Exports
 import Web.HTML.Navigator (Navigator) as Exports
 import Web.HTML.Window (Window) as Exports
 
-foreign import windowImpl :: Effect Window
-
-window :: Effect Window
-window = windowImpl
+foreign import window :: Effect Window

--- a/src/Web/HTML.purs
+++ b/src/Web/HTML.purs
@@ -74,4 +74,7 @@ import Web.HTML.Location (Location) as Exports
 import Web.HTML.Navigator (Navigator) as Exports
 import Web.HTML.Window (Window) as Exports
 
-foreign import window :: Effect Window
+foreign import windowImpl :: Effect Window
+
+window :: Effect Window
+window = windowImpl


### PR DESCRIPTION
**Prerequisites**

- [ ] Before opening a pull request, please check the HTML standard (https://dom.spec.whatwg.org/). If it doesn't appear in this spec, it may be present in the spec for one of the other `purescript-web` projects. Although MDN is a great resource, it is not a suitable reference for this project.


**Description of the change**

Bugfix: Export of window is wrong, causing the function to return itself. 

---

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
