### PR TITLE
Add HTMLDialogElement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Notable changes to this project are documented in this file. The format is based
 Breaking changes:
 
 New features:
+- Added `HTMLDialogElement` module (#77 by @kgmt0)
 
 Bugfixes:
 

--- a/src/Web/HTML/HTMLDialogElement.js
+++ b/src/Web/HTML/HTMLDialogElement.js
@@ -1,0 +1,53 @@
+export function open(dialog) {
+  return function () {
+    return dialog.open;
+  };
+}
+
+export function setOpen(value) {
+  return function (dialog) {
+    return function () {
+      dialog.open = value;
+    };
+  };
+}
+
+// ----------------------------------------------------------------------------
+
+export function returnValue(dialog) {
+  return function () {
+    return dialog.returnValue;
+  };
+}
+
+export function setReturnValue(value) {
+  return function (dialog) {
+    return function () {
+      dialog.returnValue = value;
+    };
+  };
+}
+
+// ----------------------------------------------------------------------------
+
+export function show(dialog) {
+  return function () {
+    return dialog.show();
+  };
+}
+
+export function showModal(dialog) {
+  return function () {
+    return dialog.showModal();
+  };
+}
+
+// ----------------------------------------------------------------------------
+
+export function _close(value) {
+  return function (dialog) {
+    return function () {
+      dialog.close(value);
+    };
+  };
+}

--- a/src/Web/HTML/HTMLDialogElement.purs
+++ b/src/Web/HTML/HTMLDialogElement.purs
@@ -1,0 +1,92 @@
+module Web.HTML.HTMLDialogElement
+  ( HTMLDialogElement
+  , fromHTMLElement
+  , fromElement
+  , fromNode
+  , fromChildNode
+  , fromNonDocumentTypeChildNode
+  , fromParentNode
+  , fromEventTarget
+  , toHTMLElement
+  , toElement
+  , toNode
+  , toChildNode
+  , toNonDocumentTypeChildNode
+  , toParentNode
+  , toEventTarget
+  , open
+  , setOpen
+  , returnValue
+  , setReturnValue
+  , show
+  , showModal
+  , close
+  ) where
+
+import Data.Maybe (Maybe)
+import Data.Nullable (Nullable, toNullable)
+import Effect (Effect)
+import Prelude (Unit, (<<<))
+import Unsafe.Coerce (unsafeCoerce)
+import Web.DOM (ChildNode, Element, Node, NonDocumentTypeChildNode, ParentNode)
+import Web.Event.EventTarget (EventTarget)
+import Web.HTML.HTMLElement (HTMLElement)
+import Web.Internal.FFI (unsafeReadProtoTagged)
+
+foreign import data HTMLDialogElement :: Type
+
+fromHTMLElement :: HTMLElement -> Maybe HTMLDialogElement
+fromHTMLElement = unsafeReadProtoTagged "HTMLDialogElement"
+
+fromElement :: Element -> Maybe HTMLDialogElement
+fromElement = unsafeReadProtoTagged "HTMLDialogElement"
+
+fromNode :: Node -> Maybe HTMLDialogElement
+fromNode = unsafeReadProtoTagged "HTMLDialogElement"
+
+fromChildNode :: ChildNode -> Maybe HTMLDialogElement
+fromChildNode = unsafeReadProtoTagged "HTMLDialogElement"
+
+fromNonDocumentTypeChildNode :: NonDocumentTypeChildNode -> Maybe HTMLDialogElement
+fromNonDocumentTypeChildNode = unsafeReadProtoTagged "HTMLDialogElement"
+
+fromParentNode :: ParentNode -> Maybe HTMLDialogElement
+fromParentNode = unsafeReadProtoTagged "HTMLDialogElement"
+
+fromEventTarget :: EventTarget -> Maybe HTMLDialogElement
+fromEventTarget = unsafeReadProtoTagged "HTMLDialogElement"
+
+toHTMLElement :: HTMLDialogElement -> HTMLElement
+toHTMLElement = unsafeCoerce
+
+toElement :: HTMLDialogElement -> Element
+toElement = unsafeCoerce
+
+toNode :: HTMLDialogElement -> Node
+toNode = unsafeCoerce
+
+toChildNode :: HTMLDialogElement -> ChildNode
+toChildNode = unsafeCoerce
+
+toNonDocumentTypeChildNode :: HTMLDialogElement -> NonDocumentTypeChildNode
+toNonDocumentTypeChildNode = unsafeCoerce
+
+toParentNode :: HTMLDialogElement -> ParentNode
+toParentNode = unsafeCoerce
+
+toEventTarget :: HTMLDialogElement -> EventTarget
+toEventTarget = unsafeCoerce
+
+foreign import open :: HTMLDialogElement -> Effect Boolean
+foreign import setOpen :: Boolean -> HTMLDialogElement -> Effect Unit
+
+foreign import returnValue :: HTMLDialogElement -> Effect String
+foreign import setReturnValue :: String -> HTMLDialogElement -> Effect Unit
+
+foreign import show :: HTMLDialogElement -> Effect Unit
+foreign import showModal :: HTMLDialogElement -> Effect Unit
+
+foreign import _close :: Nullable String -> HTMLDialogElement -> Effect Unit
+
+close :: Maybe String -> HTMLDialogElement -> Effect Unit
+close = _close <<< toNullable


### PR DESCRIPTION
**Prerequisites**

- [x] Before opening a pull request, please check the HTML standard (https://dom.spec.whatwg.org/). If it doesn't appear in this spec, it may be present in the spec for one of the other `purescript-web` projects. Although MDN is a great resource, it is not a suitable reference for this project.

https://html.spec.whatwg.org/#the-dialog-element

**Description of the change**

This adds a new module for `HTMLDialogElement`, which corresponds to `<dialog>`.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
