### PR TITLE
Add window.close()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Notable changes to this project are documented in this file. The format is based
 Breaking changes:
 
 New features:
+- Added `close` function for `Window` (#78 by @jmp-0x7C0)
 
 Bugfixes:
 

--- a/src/Web/HTML/Window.js
+++ b/src/Web/HTML/Window.js
@@ -82,6 +82,12 @@ export function _open(url) {
   };
 }
 
+export function close(window) {
+  return function () {
+    return window.close();
+  };
+}
+
 export function outerHeight(window) {
   return function () {
     return window.outerHeight;

--- a/src/Web/HTML/Window.purs
+++ b/src/Web/HTML/Window.purs
@@ -13,6 +13,7 @@ module Web.HTML.Window
   , moveBy
   , moveTo
   , open
+  , close
   , outerHeight
   , outerWidth
   , print
@@ -88,6 +89,8 @@ foreign import _open
   -> String
   -> Window
   -> Effect (Nullable Window)
+
+foreign import close :: Window -> Effect Unit
 
 foreign import outerHeight :: Window -> Effect Int
 


### PR DESCRIPTION
**Prerequisites**

- [ ] Before opening a pull request, please check the HTML standard (https://dom.spec.whatwg.org/). If it doesn't appear in this spec, it may be present in the spec for one of the other `purescript-web` projects. Although MDN is a great resource, it is not a suitable reference for this project.

**Description of the change**

According to the [WHATWG HTML Living Standard](https://html.spec.whatwg.org/), `Window` should have a `close` method: [window.close()](https://html.spec.whatwg.org/#dom-window-close), which has been added in this PR.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
