### PR TITLE
[Not ready to merge] Migrating `AttrName`, `ClassName`, and `PropName` to web-dom.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ New features:
 Bugfixes:
 
 Other improvements:
+- `AttrName`, `ClassName`, and `PropName` types have been migrated to [web-dom](https://github.com/purescript-web/purescript-web-dom) but are re-exported to avoid breaking compatibility. See also purescript-web/purescript-web-dom#58. (#82 by @nsaunders)
 
 ## [v4.1.0](https://github.com/purescript-web/purescript-web-html/releases/tag/v4.1.0) - 2022-09-19
 

--- a/bower.json
+++ b/bower.json
@@ -16,8 +16,11 @@
   ],
   "dependencies": {
     "purescript-js-date": "^8.0.0",
-    "purescript-web-dom": "^6.0.0",
+    "purescript-web-dom": "https://github.com/nsaunders/purescript-web-dom.git#8b1dfaa5cd",
     "purescript-web-file": "^4.0.0",
     "purescript-web-storage": "^5.0.0"
+  },
+  "resolutions": {
+    "purescript-web-dom": "8b1dfaa5cd"
   }
 }

--- a/src/Web/HTML/Common.purs
+++ b/src/Web/HTML/Common.purs
@@ -1,30 +1,3 @@
-module Web.HTML.Common where
+module Web.HTML.Common (module Exports) where
 
-import Prelude
-
-import Data.Newtype (class Newtype)
-
--- | A wrapper for property names.
--- |
--- | The phantom type `value` describes the type of value which this property
--- | requires.
-newtype PropName :: Type -> Type
-newtype PropName value = PropName String
-
-derive instance newtypePropName :: Newtype (PropName value) _
-derive newtype instance eqPropName :: Eq (PropName value)
-derive newtype instance ordPropName :: Ord (PropName value)
-
--- | A wrapper for attribute names.
-newtype AttrName = AttrName String
-
-derive instance newtypeAttrName :: Newtype AttrName _
-derive newtype instance eqAttrName :: Eq AttrName
-derive newtype instance ordAttrName :: Ord AttrName
-
--- | A wrapper for strings which are used as CSS classes.
-newtype ClassName = ClassName String
-
-derive instance newtypeClassName :: Newtype ClassName _
-derive newtype instance eqClassName :: Eq ClassName
-derive newtype instance ordClassName :: Ord ClassName
+import Web.DOM.Element (AttrName(..), ClassName(..), PropName(..)) as Exports


### PR DESCRIPTION
**Prerequisites**

- [x] Before opening a pull request, please check the HTML standard (https://html.spec.whatwg.org/). If it doesn't appear in this spec, it may be present in the spec for one of the other `purescript-web` projects. Although MDN is a great resource, it is not a suitable reference for this project.

**Description of the change**

With this change, the `AttrName`, `ClassName`, and `PropName` types are re-exported from web-dom, completing the migration discussed in purescript-web/purescript-web-dom#56 and purescript-web/purescript-web-dom#58.

> **Warning**
> As this change depends on purescript-web/purescript-web-dom#58 which is not yet merged, the `purescript-web-dom` reference in `bower.json` points to my personal fork. This will of course need to be updated before this PR can be merged.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] ~~Updated or added relevant documentation~~ N/A
- [ ] ~~Added a test for the contribution (if applicable)~~ N/A
