### PR TITLE
Update requestAnimationFrame to include timestamp parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Notable changes to this project are documented in this file. The format is based
 ## [Unreleased]
 
 Breaking changes:
+- Update requestAnimationFrame to include timestamp parameter
 
 New features:
 

--- a/src/Web/HTML/Window.purs
+++ b/src/Web/HTML/Window.purs
@@ -131,7 +131,7 @@ newtype RequestAnimationFrameId = RequestAnimationFrameId Int
 derive instance eqRequestAnimationFrameId :: Eq RequestAnimationFrameId
 derive instance ordRequestAnimationFrameId :: Ord RequestAnimationFrameId
 
-foreign import requestAnimationFrame :: Effect Unit -> Window -> Effect RequestAnimationFrameId
+foreign import requestAnimationFrame :: (Int -> Effect Unit) -> Window -> Effect RequestAnimationFrameId
 
 foreign import cancelAnimationFrame :: RequestAnimationFrameId -> Window -> Effect Unit
 


### PR DESCRIPTION
**Prerequisites**

- [x] Before opening a pull request, please check the HTML standard (https://html.spec.whatwg.org/). If it doesn't appear in this spec, it may be present in the spec for one of the other `purescript-web` projects. Although MDN is a great resource, it is not a suitable reference for this project.


**Description of the change**


Change the type signature of requestAnimationFrame
to pass the timestamp to the callback function,
matching the Web API specification where
requestAnimationFrame provides a DOMHighResTimeStamp parameter.

See. https://html.spec.whatwg.org/#animation-frames

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
