### PR TITLE
Fix document visibilityState functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Breaking changes:
 New features:
 
 Bugfixes:
+- Fixed `visibilityState` for `HTMLDocument` (#86 by @cwinebr)
 
 Other improvements:
 

--- a/src/Web/HTML/HTMLDocument.js
+++ b/src/Web/HTML/HTMLDocument.js
@@ -15,7 +15,7 @@ export function _readyState(doc) {
 }
 
 export function _visibilityState(doc) {
-  return doc.readyState;
+  return doc.visibilityState;
 }
 
 export function _activeElement(doc) {


### PR DESCRIPTION
**Prerequisites**

- [X] Before opening a pull request, please check the HTML standard (https://html.spec.whatwg.org/). If it doesn't appear in this spec, it may be present in the spec for one of the other `purescript-web` projects. Although MDN is a great resource, it is not a suitable reference for this project.


**Description of the change**

This fixes visibilityState on HTMLDocument.  The FFI code was leveraging readyState instead of visibilityState.

---

**Checklist:**

- [X] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
